### PR TITLE
Replace gorilla/csrf with net/http.CrossOriginProtection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,17 @@ docker compose down -v && docker compose up -d
 
 ## FAQ
 
-### I get "Forbidden - CSRF token invalid" when logging in!
+### I get "cross-origin request detected" (403) when submitting a form!
 
-Check your `config.yml` for `production`. If it is set to `true` and you're not
-running via SSL/TLS, the CSRF protection will not work. Change to `false` if
-you're simply developing locally, or make sure it's served behind SSL.
+CSRF protection compares the browser's `Sec-Fetch-Site` and `Origin` headers
+against the request's `Host`. A 403 means the browser considered the request
+cross-origin, which usually means you reached zauth through a different
+hostname or port than the page was served from. If zauth sits behind a reverse
+proxy, make sure the proxy forwards the original `Host` header rather than
+rewriting it to the backend address.
+
+This is no longer affected by the `production` setting in your config, and no
+longer depends on SSL/TLS.
 
 ### How can I query and test the LDAP server?
 

--- a/cmd/zauth.go
+++ b/cmd/zauth.go
@@ -69,6 +69,6 @@ func main() {
 	config = mustLoadConfig()
 	DB = db.MustConnect(config.Database)
 	email.Init(config.SendGridAPIKey)
-	go httpserver.Listen(DB, config.HTTP.ListenTo, config.Production)
+	go httpserver.Listen(DB, config.HTTP.ListenTo)
 	ldap.Listen(DB, config.LDAP) // blocking
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/dchest/passwordreset v0.0.0-20190826080013-4518b1f41006
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-sql-driver/mysql v1.10.0
-	github.com/gorilla/csrf v1.7.3
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxo
 github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
-github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=

--- a/models/httpserver/groupAdd.go
+++ b/models/httpserver/groupAdd.go
@@ -2,12 +2,10 @@ package httpserver
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"strings"
 
 	"github.com/ansel1/merry"
-	"github.com/gorilla/csrf"
 	"github.com/joshsziegler/zauth/pkg/user"
 )
 
@@ -20,7 +18,6 @@ type newGroupPageData struct {
 	User         *user.User
 	ErrorMessage string
 	Form         formNewGroup
-	CSRFField    template.HTML
 }
 
 func newFormNewGroup(r *http.Request) formNewGroup {
@@ -37,7 +34,7 @@ func NewGroupGet(c *Context, w http.ResponseWriter, r *http.Request) error {
 		return ErrPermissionDenied.Here()
 	}
 	// Handle the request
-	data := newGroupPageData{User: c.User, CSRFField: csrf.TemplateField(r)}
+	data := newGroupPageData{User: c.User}
 	Render(w, "group_new.html", data)
 	return nil
 }
@@ -49,7 +46,7 @@ func NewGroupPost(c *Context, w http.ResponseWriter, r *http.Request) error {
 		return ErrPermissionDenied.Here()
 	}
 	// Handle the request
-	data := newGroupPageData{User: c.User, CSRFField: csrf.TemplateField(r)}
+	data := newGroupPageData{User: c.User}
 	form := newFormNewGroup(r)
 	err := user.AddGroup(c.Tx, form.Name, form.Description)
 	if err != nil {

--- a/models/httpserver/login.go
+++ b/models/httpserver/login.go
@@ -1,22 +1,18 @@
 package httpserver
 
 import (
-	"html/template"
 	"net/http"
-
 	"strings"
 
 	"github.com/ansel1/merry"
-	"github.com/gorilla/csrf"
 	"github.com/joshsziegler/zauth/pkg/user"
 	"github.com/joshsziegler/zgo/pkg/log"
 )
 
 type LoginPageData struct {
-	Message   string
-	Error     string
-	Username  string
-	CSRFField template.HTML
+	Message  string
+	Error    string
+	Username string
 }
 
 // LoginGetPost handles a user's request to view the login page (GET and POST).
@@ -31,9 +27,7 @@ func LoginGetPost(c *Context, w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	// Create page data here so we don't forget to create the CSRF token
-	data := LoginPageData{CSRFField: csrf.TemplateField(r),
-		Message: c.NormalFlashMessage, Error: c.ErrorFlashMessage}
+	data := LoginPageData{Message: c.NormalFlashMessage, Error: c.ErrorFlashMessage}
 
 	switch r.Method {
 	case "GET":

--- a/models/httpserver/newUser.go
+++ b/models/httpserver/newUser.go
@@ -2,12 +2,10 @@ package httpserver
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"strings"
 
 	"github.com/ansel1/merry"
-	"github.com/gorilla/csrf"
 	"github.com/joshsziegler/zauth/pkg/user"
 )
 
@@ -21,7 +19,6 @@ type newUserPageData struct {
 	User         *user.User
 	ErrorMessage string
 	Form         formNewUser
-	CSRFField    template.HTML
 }
 
 func newFormNewUser(r *http.Request) formNewUser {
@@ -39,7 +36,7 @@ func NewUserGet(c *Context, w http.ResponseWriter, r *http.Request) error {
 		return ErrPermissionDenied.Here()
 	}
 	// Handle the request
-	data := newUserPageData{User: c.User, CSRFField: csrf.TemplateField(r)}
+	data := newUserPageData{User: c.User}
 	Render(w, "user_new.html", data)
 	return nil
 }
@@ -51,7 +48,7 @@ func NewUserPost(c *Context, w http.ResponseWriter, r *http.Request) error {
 		return ErrPermissionDenied.Here()
 	}
 	// Handle the request
-	data := newUserPageData{User: c.User, CSRFField: csrf.TemplateField(r)}
+	data := newUserPageData{User: c.User}
 	form := newFormNewUser(r)
 	newUser, err := user.NewUser(c.Tx, form.FirstName, form.LastName, form.Email)
 	if err != nil {

--- a/models/httpserver/passwordReset.go
+++ b/models/httpserver/passwordReset.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/ansel1/merry"
-	"github.com/gorilla/csrf"
 
 	"github.com/joshsziegler/zauth/pkg/password"
 	"github.com/joshsziegler/zauth/pkg/user"
@@ -40,7 +39,6 @@ func PasswordResetGetPost(c *Context, w http.ResponseWriter, r *http.Request) er
 	}
 
 	// Token is valid: continue
-	// Create page data here so we don't forget to create the CSRF token
 	requestedUser, err := c.GetUser(requestedUsername)
 	if err != nil {
 		return err
@@ -50,7 +48,6 @@ func PasswordResetGetPost(c *Context, w http.ResponseWriter, r *http.Request) er
 		Message:           c.NormalFlashMessage,
 		Error:             c.ErrorFlashMessage,
 		RequestedUser:     requestedUser,
-		CSRFField:         csrf.TemplateField(r),
 		PasswordMinLength: password.MinLength,
 		PasswordMaxLength: password.MaxLength,
 	}

--- a/models/httpserver/userSetPassword.go
+++ b/models/httpserver/userSetPassword.go
@@ -1,11 +1,9 @@
 package httpserver
 
 import (
-	"html/template"
 	"net/http"
 
 	"github.com/ansel1/merry"
-	"github.com/gorilla/csrf"
 	"github.com/joshsziegler/zauth/pkg/password"
 	"github.com/joshsziegler/zauth/pkg/user"
 )
@@ -17,7 +15,6 @@ type userSetPasswordPageData struct {
 	RequestingUser user.User
 	// RequestedUser is the User they want to view on this page.
 	RequestedUser     user.User
-	CSRFField         template.HTML
 	PasswordMinLength int
 	PasswordMaxLength int
 }
@@ -40,7 +37,6 @@ func userSetPassword(c *Context, w http.ResponseWriter, r *http.Request) error {
 		Error:             c.ErrorFlashMessage,
 		RequestingUser:    *c.User,
 		RequestedUser:     requestedUser,
-		CSRFField:         csrf.TemplateField(r),
 		PasswordMinLength: password.MinLength,
 		PasswordMaxLength: password.MaxLength,
 	}

--- a/models/httpserver/web.go
+++ b/models/httpserver/web.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"net/http"
 
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/jmoiron/sqlx"
@@ -32,7 +31,7 @@ const (
 )
 
 // Listen performs setup and runs the Web server (blocking)
-func Listen(database *sqlx.DB, listenTo string, isProduction bool) {
+func Listen(database *sqlx.DB, listenTo string) {
 	DB = database
 
 	// Setup sessions using secure cookies
@@ -72,10 +71,16 @@ func Listen(database *sqlx.DB, listenTo string, isProduction bool) {
 	// /groups/{groupname} - If none, show all if admin or redirect to self TODO: implement
 	r.Handle("/reset-password/{token}", Wrap(r, PasswordResetGetPost, false)).Methods("GET", "POST")
 
+	// CSRF protection is origin-based (Sec-Fetch-Site / Origin vs. Host) rather
+	// than token-based: gorilla/csrf has been unmaintained since April 2025 and
+	// carries an unfixed advisory (CVE-2025-47909), and its replacement landed
+	// in the standard library in Go 1.25. Requests carrying neither header are
+	// allowed, since CSRF is an attack only a browser can be tricked into.
+	csrfProtect := http.NewCrossOriginProtection()
+
 	// Start the HTTP servers
 	log.Infof("HTTP server listening on: %s", listenTo)
-	err = http.ListenAndServe(listenTo,
-		csrf.Protect(secrets.CSRFKey(), csrf.Secure(isProduction))(r))
+	err = http.ListenAndServe(listenTo, csrfProtect.Handler(r))
 	if err != nil {
 		log.Fatalf("error running http server: %s", err)
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -20,15 +20,14 @@ var (
 	store secrets
 )
 
-// secrets holds four key secrets for running the web server that should be
-// saved between runs (to prevent user sessions, cookies, and CSRF tokens from
-// being invalidated, and to provide password reset tokens).
+// secrets holds the key secrets for running the web server that should be
+// saved between runs (to prevent user sessions and cookies from being
+// invalidated, and to provide password reset tokens).
 //
 // These cannot be changed after init(), and are only provided via getters!
 type secrets struct {
 	AuthKey             []byte
 	EncryptionKey       []byte
-	CSRFKey             []byte
 	PasswordResetSecret []byte
 }
 
@@ -42,11 +41,6 @@ func AuthKey() []byte {
 // Gorilla docs suggest 32 bytes long for AES-256.
 func EncryptionKey() []byte {
 	return store.EncryptionKey
-}
-
-// CSRFKey is used for Cross Site Request Forgery (CSRF) protection
-func CSRFKey() []byte {
-	return store.CSRFKey
 }
 
 // PasswordResetSecret is used for securing password reset tokens.
@@ -79,10 +73,6 @@ func init() {
 	}
 	if len(store.EncryptionKey) < 1 {
 		store.EncryptionKey = securecookie.GenerateRandomKey(32)
-		writeFile = true
-	}
-	if len(store.CSRFKey) < 1 {
-		store.CSRFKey = securecookie.GenerateRandomKey(32)
 		writeFile = true
 	}
 	if len(store.PasswordResetSecret) < 1 {

--- a/templates/group_new.html
+++ b/templates/group_new.html
@@ -20,7 +20,6 @@
             <textarea id="DescriptionInput" name="Description" type="text"
                 class="u-full-width" required>{{.Form.Description}}</textarea>
         </div>
-        {{ .CSRFField }}
         <input class="button-primary u-full-width" type="submit" value="Create">
     </form>
 </section>

--- a/templates/login.html
+++ b/templates/login.html
@@ -14,7 +14,6 @@
             placeholder="jane.doe" value="{{ .Username }}" required >
         <label for="password" class="">Password</label>
         <input name="password" type="password" class="u-full-width" required>
-        {{ .CSRFField }}
         <button type="submit" class="button-primary">Login</button>
     </form>
 </section>

--- a/templates/user_new.html
+++ b/templates/user_new.html
@@ -26,7 +26,6 @@
             <input id="EmailInput" name="Email" type="text" 
                 value="{{.Form.Email}}" class="u-full-width" required>
         </div>
-        {{ .CSRFField }}
         <input class="button-primary u-full-width" type="submit" value="Create">
     </form>
 </section>

--- a/templates/user_set_password.html
+++ b/templates/user_set_password.html
@@ -21,7 +21,6 @@
                 type="password" value="" class="u-full-width"
                 required minlength="{{.PasswordMinLength}}" >
         </div>
-        {{ .CSRFField }}
         <input class="button-primary u-full-width" type="submit" 
             value="Change Password">
     </form>


### PR DESCRIPTION
gorilla/csrf has been unmaintained since v1.7.3 (April 2025) and carries CVE-2025-47909, for which no patched release exists or is planned: the TrustedOrigins check ignores the scheme, so trusting a host also trusts its plaintext HTTP origin. zauth never called TrustedOrigins and so was not exploitable, but the dependency is a dead end.

Go 1.25 shipped the maintained replacement in the standard library, so drop the dependency entirely rather than pinning an abandoned one.

This swaps token-based protection for origin-based protection (Sec-Fetch-Site / Origin compared against Host), which removes the per-form hidden token, the CSRF cookie, and the persisted CSRF key:

- Listen() no longer takes isProduction; the old csrf.Secure() toggle has no equivalent, since nothing now depends on the TLS state.
- secrets.CSRFKey and the CSRFKey field are removed. Existing secrets.json files keep working; the field is ignored on load.
- CSRFField is removed from the four page-data structs and templates.

One behavior change worth knowing: requests carrying neither Sec-Fetch-Site nor Origin are allowed through, matching the standard library, on the grounds that CSRF is an attack only a browser can be tricked into performing.

Verified against a live server: cross-site POSTs are rejected with 403 while same-origin login and group-creation flows still succeed.